### PR TITLE
Add GNOME 47 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,6 @@
   "url": "https://github.com/GittyMac/PanelNote",
   "version": 1,
   "shell-version": [
-    "45", "46"
+    "45", "46", "47"
   ]
 }


### PR DESCRIPTION
According to my tests, the application is compatible with the latest Gnome version. So, I've included shell version 47 into metadata.json for the extension to work with Gnome 47.